### PR TITLE
fix: project deletion UX and create project error handling

### DIFF
--- a/src/features/projects/hooks/index.ts
+++ b/src/features/projects/hooks/index.ts
@@ -52,8 +52,9 @@ export function useDeleteProjectMutation() {
 
   return useMutation({
     mutationFn: (id: string) => projectsService.deleteProject(id),
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: projectKeys.all });
+    onSuccess: (_data, id) => {
+      queryClient.removeQueries({ queryKey: projectKeys.byId(id) });
+      void queryClient.invalidateQueries({ queryKey: projectKeys.all });
     },
   });
 }

--- a/src/pages/projects/CreateProjectPage.tsx
+++ b/src/pages/projects/CreateProjectPage.tsx
@@ -1,4 +1,5 @@
-﻿import { useNavigate } from "react-router-dom";
+﻿import toast from "react-hot-toast";
+import { useNavigate } from "react-router-dom";
 import { useCreateProjectMutation } from "@/features/projects/hooks";
 import { useProfileQuery } from "@/features/profile/hooks";
 import { ProjectForm, ProjectFormValues } from "@/features/projects/components/ProjectForm";
@@ -8,51 +9,55 @@ import { documentsApi } from "@/features/projects/services/documents.api";
 export function CreateProjectPage() {
   const navigate = useNavigate();
   const mutation = useCreateProjectMutation();
-  const { data: profile } = useProfileQuery();
+  const { data: profile, isLoading: isProfileLoading } = useProfileQuery();
 
   async function handleSubmit(values: ProjectFormValues) {
-    const managerJob = {
-      title: "manager",
-      skills: [],
-    };
+    try {
+      const managerJob = {
+        title: "manager",
+        skills: [],
+      };
 
-    const jobs = [managerJob, ...values.jobs];
+      const jobs = [managerJob, ...values.jobs];
 
-    const members = profile
-      ? [
-          {
-            userId: profile.id,
-            role: ProjectMemberRoles.ADMIN,
-          },
-        ]
-      : [];
+      const members = profile
+        ? [
+            {
+              userId: profile.id,
+              role: ProjectMemberRoles.ADMIN,
+            },
+          ]
+        : [];
 
-    const project = await mutation.mutateAsync({
-      name: values.name,
-      description: values.description,
-      repositoryUrl: values.repositoryUrl,
-      jobs,
-      members,
-    });
+      const project = await mutation.mutateAsync({
+        name: values.name,
+        description: values.description,
+        repositoryUrl: values.repositoryUrl,
+        jobs,
+        members,
+      });
 
-    if (values.pendingFiles.length > 0) {
-      await documentsApi.uploadDocuments(project.id, values.pendingFiles);
-    }
-
-    const createdJobs = project.jobs ?? project.job ?? [];
-    for (const [indexStr, files] of Object.entries(values.jobPendingFiles)) {
-      if (files.length === 0) continue;
-      const index = Number(indexStr);
-      const jobTitle = values.jobs[index]?.title;
-      if (!jobTitle) continue;
-
-      const createdJob = createdJobs.find((j) => j.title === jobTitle);
-      if (createdJob?.id) {
-        await documentsApi.uploadJobDocuments(project.id, String(createdJob.id), files);
+      if (values.pendingFiles.length > 0) {
+        await documentsApi.uploadDocuments(project.id, values.pendingFiles);
       }
-    }
 
-    navigate("/projects");
+      const createdJobs = project.jobs ?? project.job ?? [];
+      for (const [indexStr, files] of Object.entries(values.jobPendingFiles)) {
+        if (files.length === 0) continue;
+        const index = Number(indexStr);
+        const jobTitle = values.jobs[index]?.title;
+        if (!jobTitle) continue;
+
+        const createdJob = createdJobs.find((j) => j.title === jobTitle);
+        if (createdJob?.id) {
+          await documentsApi.uploadJobDocuments(project.id, String(createdJob.id), files);
+        }
+      }
+
+      navigate("/projects");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to create project");
+    }
   }
 
   return (
@@ -61,7 +66,7 @@ export function CreateProjectPage() {
       backLabel="Back to Projects"
       heading="Create New Project"
       subheading="Set up a new workspace for your team's onboarding."
-      isPending={mutation.isPending}
+      isPending={mutation.isPending || isProfileLoading}
       submitLabel="Create Project"
       onSubmit={handleSubmit}
     />

--- a/src/pages/projects/ProjectSettingsPage.tsx
+++ b/src/pages/projects/ProjectSettingsPage.tsx
@@ -1,4 +1,4 @@
-﻿import { useEffect, useState } from "react";
+﻿import { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import toast from "react-hot-toast";
 import { useProjectQuery, useUpdateProjectMutation, useDeleteProjectMutation } from "@/features/projects/hooks";
@@ -21,6 +21,7 @@ export function ProjectSettingsPage() {
   const mutation = useUpdateProjectMutation();
   const deleteMutation = useDeleteProjectMutation();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const isDeletingRef = useRef(false);
   const role = useProjectRole(projectId, project?.members);
   const { data: documents = [] } = useProjectDocumentsQuery(projectId);
   const uploadMutation = useUploadDocumentsMutation(projectId);
@@ -42,11 +43,11 @@ export function ProjectSettingsPage() {
   });
 
   useEffect(() => {
-    if (isError && !deleteMutation.isSuccess) {
+    if (isError && !isDeletingRef.current) {
       toast.error("Failed to load project.");
       navigate("/projects");
     }
-  }, [isError, deleteMutation.isSuccess, navigate]);
+  }, [isError, navigate]);
 
   useEffect(() => {
     if (!isLoading && role !== null && role !== ProjectMemberRoles.ADMIN) {
@@ -60,10 +61,12 @@ export function ProjectSettingsPage() {
 
   async function handleDeleteProject() {
     try {
+      isDeletingRef.current = true;
       await deleteMutation.mutateAsync(projectId);
       toast.success("Project deleted successfully.");
       navigate("/projects", { replace: true });
     } catch {
+      isDeletingRef.current = false;
       toast.error("Failed to delete project.");
     }
   }


### PR DESCRIPTION
- useDeleteProjectMutation: use removeQueries + fire-and-forget invalidation to prevent stale cache from triggering a 404 fetch after deletion
- ProjectSettingsPage: add isDeletingRef guard so the isError effect does not fire a false 'Failed to load project' toast when the query is invalidated post-deletion; show success toast and navigate on successful delete
- CreateProjectPage: add try/catch with toast.error in handleSubmit, and guard submission with isProfileLoading to prevent early submit before profile loads